### PR TITLE
Add SQL indexes and adjust sample query

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,4 @@ Then run your queries in SQLite, e.g.:
 
 If both rvk and bk have been imported co-occurrences can be queried via JOIN:
 
-    SELECT b.notation, count(*) AS freq FROM subjects AS b JOIN subjects AS a ON a.ppn=b.ppn WHERE a.voc="rvk" AND b.voc="bk" AND a.notation="NQ 2350" GROUP BY b.notation ORDER BY freq;
-
+    SELECT b.notation, count(*) AS freq FROM subjects AS b JOIN subjects AS a ON a.ppn=b.ppn WHERE a.voc="rvk" AND b.voc="bk" AND a.notation="NQ 2350" GROUP BY b.notation ORDER BY freq DESC LIMIT 10;

--- a/import-subjects.sql
+++ b/import-subjects.sql
@@ -4,6 +4,9 @@ CREATE TABLE IF NOT EXISTS subjects (
   voc TEXT NOT NULL,
   notation TEXT NOT NULL
 );
+CREATE INDEX idx_notation on subjects (notation);
+CREATE INDEX idx_ppn on subjects (ppn);
+CREATE INDEX idx_voc on subjects (voc);
 
 .mode tabs
 .import subjects.tsv subjects

--- a/import-subjects.sql
+++ b/import-subjects.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS subjects (
 );
 CREATE INDEX idx_notation on subjects (notation);
 CREATE INDEX idx_ppn on subjects (ppn);
-CREATE INDEX idx_voc on subjects (voc);
 
 .mode tabs
 .import subjects.tsv subjects


### PR DESCRIPTION
Adding indexes on `ppn` and `notation` makes the sample query for co-occurrences a lot faster. The index on `voc` is optional, but helps with the other query.

I also adjusted the sample query for co-occurrences to something that would actually be used in practice, i.e. order by frequency **descending** and limit the results.